### PR TITLE
Moved common utilities into the educationplatform static

### DIFF
--- a/static.epsilon/public/epsilon_tool.json
+++ b/static.epsilon/public/epsilon_tool.json
@@ -295,31 +295,7 @@
                 ]
 
             },
-
-            {
-
-                "id": "console",
-
-                "name": "console",
-
-                "panelclass": "ConsolePanel",
-
-                "icon": "images/console.gif"
-
-            },
-
-            {
-
-                "id": "problem",
-
-                "name": "problem",
-                
-                "panelclass": "OutputPanel",
-
-                "icon": "problems"
-
-            },
-
+            
             {
 
                 "id": "emfgraph",


### PR DESCRIPTION
Moved common utilities into the educationplatform static to help with deployment and tidy up.