### PR TITLE
Removed emfatic render button that fails validation

### DIFF
--- a/static.emfatic/public/emfatic_tool.json
+++ b/static.emfatic/public/emfatic_tool.json
@@ -62,12 +62,6 @@
 
                 "buttons" : [ 
                       { 
-                        "id": "refresh-button", 
-                        "icon": "refresh",
-                        "renderfunction": "",
-                        "hint": "Render the metamodel class diagram" 
-                      }, 
-                      { 
                         "id": "help-button", 
                         "icon": "info",
                         "url": "https://www.eclipse.org/emfatic/",


### PR DESCRIPTION
Removed emfatic render button as no function to do the conversion and the empty field caused a validation error by changes introduced in mdenet/educationplatform#115.