### PR TITLE
Reduced Xtext output log

### DIFF
--- a/xtext/editorserver/build.sh
+++ b/xtext/editorserver/build.sh
@@ -21,7 +21,7 @@ unzip -q $archiveFile
 
 cd ./*.parent
 
-mvn --batch-mode clean install
+mvn --batch-mode --quiet clean install
 
 cd ..
 


### PR DESCRIPTION
Xtext tool service set maven build mode to quiet to reduce the output of irrelevant logs.

Supersedes #26 as a simpler solution and closes #23.