### PR TITLE
Ensure generated meta-model is part of the Xtext WAR

### DIFF
--- a/xtext/editorserver/build.sh
+++ b/xtext/editorserver/build.sh
@@ -47,6 +47,10 @@ mv $modeBasePath/$modeFileName ../acemodebundler/src/$modeFileName
 npm --prefix ../acemodebundler run build
 mv ../acemodebundler/dist/$modeFileName ./$modeBasePath/$modeFileName
 
+# Add Xtext-generated meta-model
+metamodelName=$(find $buildDir -name '*.ecore')
+cp $metamodelName ./xtext-resources/generated/meta-model.ecore
+
 # Add tomcat http headers config
 cp ../acemodebundler/web.xml ./WEB-INF/web.xml
 
@@ -54,5 +58,3 @@ zip -q -m -r $archiveFile.war .
 
 # Deploy
 mv $archiveFile.war $deployDir/$archiveFile.war
-
-


### PR DESCRIPTION
This PR adds code to ensure the `.ecore` file generated by Xtext is included in the WAR file used to serve the generated editor to learners. As a result, this file will become accessible to any activities using the generated editor -- for example so that the meta-model can be shown to learners.