### PR TITLE
Resource management of editor instances

### DIFF
--- a/services/com.mde-network.ep.toolfunctions.xtextfunction/README.md
+++ b/services/com.mde-network.ep.toolfunctions.xtextfunction/README.md
@@ -1,0 +1,33 @@
+# MDENet Xtext Tool Function
+
+Prerequisites:
+- [Maven](https://maven.apache.org/)
+
+To build the tool functions, at the root directory of the platformtools repository  run the following commands. 
+
+```
+mvn clean
+mvn install
+```
+
+To Run the MDENet Xtext tool function backend service locally, navigate to the `com.mde-network.ep.toolfunctions.epsilonfunction` subdirectory and run the following commands.
+
+```
+mvn function:run -Drun.functionTarget=com.mdenetnetwork.ep.toolfunctions.xtextfunction.RunXtextFunction -Drun.port=9094'
+```
+
+To provide a usable service an editor server is required in addition to the Xtext tool function.
+
+
+## Editor Server
+The editor server component receives an Xtext project from an Xtext tool function, builds the project, and deploys it making a web-editor available to use by an education platform instance.
+
+The editor server is provided as a docker file located in the following directory of this repository `xtext/`.
+
+### Environment Variables
+This section documents the environment variables supported by the Editor Server.
+
+| Name                    | Type | Description | Example | Default | 
+| ---                     | ---  | ---         | --- | ---     |
+| XTEXT_ES_STOP_CRON_TIME | Cron Time | The date time to stop the editor server in unix CRON format. If unset the editor server will not stop. | `4 0 * * *` | Unset |
+

--- a/services/com.mde-network.ep.toolfunctions.xtextfunction/README.md
+++ b/services/com.mde-network.ep.toolfunctions.xtextfunction/README.md
@@ -24,10 +24,18 @@ The editor server component receives an Xtext project from an Xtext tool functio
 
 The editor server is provided as a docker file located in the following directory of this repository `xtext/`.
 
+Upon restart, all editor instances and the contents of received projects and build paths are cleaned.
+
 ### Environment Variables
 This section documents the environment variables supported by the Editor Server.
 
-| Name                    | Type | Description | Example | Default | 
-| ---                     | ---  | ---         | --- | ---     |
-| XTEXT_ES_STOP_CRON_TIME | Cron Time | The date time to stop the editor server in unix CRON format. If unset the editor server will not stop. | `4 0 * * *` | Unset |
-
+| Name                    | Type | Description | Example | 
+| ---                     | ---  | ---         | --- | 
+| ES_BUILD_LOCATION       | Path | The path where Xtext project build files are stored.  | /home/build  |
+| ES_DEPLOY_FILE_LOCATION | Path |  The path to the tomcat webapp directory where built editor instances are deployed.  | /home/deploy  |
+| ES_UPLOAD_LOCATION      | Path |  The path where received Xtext project zip archives are stored.  |  /home/uploads |
+| ES_PORT                 | Int | The port of the editor server. | 1234  |
+| INSTALL_DIR             | Path | The path where required tools are installed. | /usr/local |
+| NODE_VERSION            | String | The version of Node.js to use. | 19.0.0 |
+|  TS_PORT                | Int | The port of the education platform tool service | 1234 |
+| XTEXT_ES_STOP_CRON_TIME | Cron Time | The date time to stop the editor server in unix CRON format. If unset the editor server will not stop. | `* 4 * * *` | 

--- a/xtext/Dockerfile
+++ b/xtext/Dockerfile
@@ -94,14 +94,19 @@ EXPOSE ${TS_PORT}
 EXPOSE 8080
 
 COPY xtext/start.sh ${ES_DIR}/start.sh
+COPY xtext/cron-setup.sh ${ES_DIR}/cron-setup.sh
 
 
 RUN chmod +x ${ES_DIR}/start.sh
+RUN chmod +x ${ES_DIR}/cron-setup.sh
 
 # deploy tool static files
 COPY --from=toolstaticbuild /usr/src/mdenet-tool/dist/ROOT.war ${ES_DEPLOY_FILE_LOCATION}/ROOT.war
 
 # Cron time for scheduled stop
 ENV XTEXT_ES_STOP_CRON_TIME="* 4 * * *"
+
+# setup cron job to periodically stop the server
+RUN ./cron-setup.sh
 
 ENTRYPOINT [ "/bin/bash", "start.sh" ]

--- a/xtext/Dockerfile
+++ b/xtext/Dockerfile
@@ -51,6 +51,12 @@ ENV ES_PORT=10001
 
 ENV INSTALL_DIR=/usr/local
 
+# Paths for editor builds
+ENV ES_DIR=/editorserver
+ENV ES_BUILD_LOCATION=${ES_DIR}/build
+ENV ES_UPLOAD_LOCATION=${ES_DIR}/uploads
+ENV ES_DEPLOY_FILE_LOCATION=${CATALINA_HOME}/webapps 
+
 # The release of node to install
 ENV NODE_VERSION=19.9.0
 ENV NODE_RELEASE=node-v${NODE_VERSION}-linux-x64
@@ -72,13 +78,13 @@ COPY --from=toolfunctions /root/.m2 /root/.m2
 COPY --from=toolfunctions /usr/src/toolfunctions /toolservice
 
 COPY xtext/acemodebundler /acemodebundler
-COPY xtext/editorserver /editorserver
+COPY xtext/editorserver ${ES_DIR}
 
 WORKDIR /acemodebundler
 
 RUN npm ci 
 
-WORKDIR /editorserver
+WORKDIR ${ES_DIR}
 
 RUN npm ci --omit=dev
 
@@ -87,13 +93,13 @@ EXPOSE ${TS_PORT}
 #8080 is the default tomcat public port
 EXPOSE 8080
 
-COPY xtext/start.sh /editorserver/start.sh
+COPY xtext/start.sh ${ES_DIR}/start.sh
 
 
-RUN chmod +x /editorserver/start.sh
+RUN chmod +x ${ES_DIR}/start.sh
 
 # deploy tool static files
-COPY --from=toolstaticbuild /usr/src/mdenet-tool/dist/ROOT.war /usr/local/tomcat/webapps/ROOT.war
+COPY --from=toolstaticbuild /usr/src/mdenet-tool/dist/ROOT.war ${ES_DEPLOY_FILE_LOCATION}/ROOT.war
 
 # Cron time for scheduled stop
 ENV XTEXT_ES_STOP_CRON_TIME="* 4 * * *"

--- a/xtext/Dockerfile
+++ b/xtext/Dockerfile
@@ -55,7 +55,7 @@ ENV INSTALL_DIR=/usr/local
 ENV NODE_VERSION=19.9.0
 ENV NODE_RELEASE=node-v${NODE_VERSION}-linux-x64
 
-RUN apt-get update && apt-get install -y --no-install-recommends unzip zip xz-utils maven 
+RUN apt-get update && apt-get install -y --no-install-recommends unzip zip xz-utils maven cron psmisc
 
 # Install node
 WORKDIR $INSTALL_DIR
@@ -94,5 +94,8 @@ RUN chmod +x /editorserver/start.sh
 
 # deploy tool static files
 COPY --from=toolstaticbuild /usr/src/mdenet-tool/dist/ROOT.war /usr/local/tomcat/webapps/ROOT.war
+
+# Cron time for scheduled stop
+ENV XTEXT_ES_STOP_CRON_TIME="* 4 * * *"
 
 ENTRYPOINT [ "/bin/bash", "start.sh" ]

--- a/xtext/cron-setup.sh
+++ b/xtext/cron-setup.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+if [ ! -z "${XTEXT_ES_STOP_CRON_TIME}" ]; then 
+        (crontab -l; echo "${XTEXT_ES_STOP_CRON_TIME}" echo Scheduled shutdown triggered. "&&" killall -u root) | crontab - 
+        crontab -l 
+        echo cron job for scheduled shutdown configured.; 
+fi

--- a/xtext/editorserver/build.sh
+++ b/xtext/editorserver/build.sh
@@ -1,8 +1,8 @@
 #! /bin/bash
 
 archiveFile=$1
-buildDir=$PWD/build/$archiveFile
-deployDir=/usr/local/tomcat/webapps
+buildDir=${ES_BUILD_LOCATION}/$archiveFile
+deployDir=${ES_DEPLOY_FILE_LOCATION}
 
 acemodebundlerDir=/acemodebundler
 modeBasePath=xtext-resources/generated

--- a/xtext/start.sh
+++ b/xtext/start.sh
@@ -4,6 +4,13 @@
 find ${CATALINA_HOME}/webapps/ -type f -not -name 'ROOT.war' -delete
 find ${CATALINA_HOME}/webapps/ -type d -not -name 'ROOT' -delete
 
+# setup cron job to periodically stop the server
+if [ ! -z "${XTEXT_ES_STOP_CRON_TIME}" ]; then
+    (crontab -l; echo "${XTEXT_ES_STOP_CRON_TIME}" echo Scheduled shutdown triggered. "&&" killall -u root) | crontab -
+    crontab -l
+    echo cron job for scheduled shutdown configured.
+fi
+
 # start tomcat
 catalina.sh run &
 
@@ -15,6 +22,9 @@ catalina.sh run &
 
 # start editorserver
 node ./src/server.js &
+
+# start cron
+cron
 
 # wait for them all
 wait -n

--- a/xtext/start.sh
+++ b/xtext/start.sh
@@ -1,9 +1,15 @@
 #! /bin/bash
 
-# clean any previous editor instances
-find ${CATALINA_HOME}/webapps/ -type f -not -name 'ROOT.war' -delete
-find ${CATALINA_HOME}/webapps/ -mindepth 1 -type d -not -name 'ROOT' -exec rm -rf {} \+
-echo Old instances cleaned.
+# clean any previous editor instances and builds
+rm -rf ${ES_BUILD_LOCATION}/*
+echo Old builds cleaned.
+
+rm -rf ${ES_UPLOAD_LOCATION}/*
+echo Old uploads cleaned.
+
+find ${ES_DEPLOY_FILE_LOCATION}/ -type f -not -name 'ROOT.war' -delete
+find ${ES_DEPLOY_FILE_LOCATION}/ -mindepth 1 -type d -not -name 'ROOT' -exec rm -rf {} \+ 
+echo Old editor instances cleaned.
 
 # setup cron job to periodically stop the server
 if [ ! -z "${XTEXT_ES_STOP_CRON_TIME}" ]; then

--- a/xtext/start.sh
+++ b/xtext/start.sh
@@ -2,7 +2,8 @@
 
 # clean any previous editor instances
 find ${CATALINA_HOME}/webapps/ -type f -not -name 'ROOT.war' -delete
-find ${CATALINA_HOME}/webapps/ -type d -not -name 'ROOT' -delete
+find ${CATALINA_HOME}/webapps/ -mindepth 1 -type d -not -name 'ROOT' -exec rm -rf {} \+
+echo Old instances cleaned.
 
 # setup cron job to periodically stop the server
 if [ ! -z "${XTEXT_ES_STOP_CRON_TIME}" ]; then

--- a/xtext/start.sh
+++ b/xtext/start.sh
@@ -11,13 +11,6 @@ find ${ES_DEPLOY_FILE_LOCATION}/ -type f -not -name 'ROOT.war' -delete
 find ${ES_DEPLOY_FILE_LOCATION}/ -mindepth 1 -type d -not -name 'ROOT' -exec rm -rf {} \+ 
 echo Old editor instances cleaned.
 
-# setup cron job to periodically stop the server
-if [ ! -z "${XTEXT_ES_STOP_CRON_TIME}" ]; then
-    (crontab -l; echo "${XTEXT_ES_STOP_CRON_TIME}" echo Scheduled shutdown triggered. "&&" killall -u root) | crontab -
-    crontab -l
-    echo cron job for scheduled shutdown configured.
-fi
-
 # start tomcat
 catalina.sh run &
 

--- a/xtext/start.sh
+++ b/xtext/start.sh
@@ -1,5 +1,8 @@
-
 #! /bin/bash
+
+# clean any previous editor instances
+find ${CATALINA_HOME}/webapps/ -type f -not -name 'ROOT.war' -delete
+find ${CATALINA_HOME}/webapps/ -type d -not -name 'ROOT' -delete
 
 # start tomcat
 catalina.sh run &


### PR DESCRIPTION
Simple resource management of editor instances, instances are cleaned on server startup. A cron job runs to stop the editor server at an interval configurable by variable XTEXT_ES_STOP_CRON_TIME, the service is  started by docker restart policy ensured by PR mdenet/educationplatform-docker#44.

The default setting is for this to be once a day at 4am.

For mdenet/educationplatform#155.