### PR TITLE
Enable proper display of Ecore files

### DIFF
--- a/static.emf/public/emf_tool.json
+++ b/static.emf/public/emf_tool.json
@@ -1,111 +1,113 @@
 {
-"tool": 
-    {
-        "id": "emf",
-
-        "name": "Emf",
-
-        "version": "0.0.1",
-        
-        "author": "MDENet",
-        
-        "homepage": "https://github.com/mdenet/platformtools",
-
-        "functions": [
-
-            {
-
-                "id": "function-ecoretodiagram",
-
-                "name": "Conversion - Ecore To Diagram",
-
-                "parameters": [ {"name":"input", "type":"ecore"} ],
-
-                "returnType": "diagram",
-
-                "path": "http://"
-
-            },
-
-            {
-
-                "id": "function-xmitodiagram",
-
-                "name": "Conversion - Xmi To Diagram",
-
-                "parameters": [ {"name":"input", "type":"xmi"} ],
-
-                "returnType": "diagram",
-
-                "path": "http://"
-
-            }
-        ],
-
-
-
-        "panelDefs": [
-
-            {
-
-                "id": "ecore",
-
-                "name": "Ecore",
-
-                "panelclass": "ProgramPanel",
-
-                "icon": "ecore",
-
-                "language": "ecore",
-
-                "buttons" : [ 
-                      { 
-                        "id": "refresh-button", 
-                        "icon": "refresh",
-                        "renderfunction": "function-ecoretodiagram",
-                        "hint": "Render the metamodel class diagram" 
-                      }, 
-                      { 
-                        "id": "help-button", 
-                        "icon": "info",
-                        "url": "https://www.eclipse.org/modeling/emf/",
-                        "hint": "EMF Homepage" 
-                      } 
-                ]
-
-            },
-
-            {
-
-                "id": "xmi",
-
-                "name": "XMI",
-
-                "panelclass": "ProgramPanel",
-
-                "icon": "xmi",
-
-                "language": "xmi",
-
-                "buttons" : [ 
-                    { 
-                      "id": "refresh-button", 
-                      "icon": "refresh",
-                      "renderfunction": "function-flexmitograph",
-                      "hint": "Render the model object diagram" 
-                    }, 
-                    { 
-                      "id": "help-button", 
-                      "icon": "info",
-                      "url": "https://www.omg.org/spec/XMI/",
-                      "hint": "OMG - XML Metadata Interchange" 
-                    }          
-                ]
-
-            }
-
-        ]
+    "tool": 
+        {
+            "id": "emf",
+    
+            "name": "Emf",
+    
+            "version": "0.0.1",
+            
+            "author": "MDENet",
+            
+            "homepage": "https://github.com/mdenet/platformtools",
+    
+            "functions": [
+    
+                {
+    
+                    "id": "function-ecoretodiagram",
+    
+                    "name": "Conversion - Ecore To Diagram",
+    
+                    "parameters": [ 
+                        {"name": "language", "type": "text"},
+                        {"name": "emfatic",  "type": "emfatic"} ],
+    
+                    "returnType": "diagram",
+    
+                    "path": "http://127.0.0.1:8070/emfatic2plantuml"
+    
+                },
+    
+                {
+    
+                    "id": "function-xmitodiagram",
+    
+                    "name": "Conversion - Xmi To Diagram",
+    
+                    "parameters": [ {"name":"input", "type":"xmi"} ],
+    
+                    "returnType": "diagram",
+    
+                    "path": "http://"
+    
+                }
+            ],
+    
+    
+    
+            "panelDefs": [
+    
+                {
+    
+                    "id": "ecore",
+    
+                    "name": "Ecore",
+    
+                    "panelclass": "ProgramPanel",
+    
+                    "icon": "ecore",
+    
+                    "language": "ecore",
+    
+                    "buttons" : [ 
+                          { 
+                            "id": "to_mm_diagram", 
+                            "icon": "diagram-generate",
+                            "actionfunction": "function-ecoretodiagram",
+                            "hint": "Render the metamodel class diagram" 
+                          }, 
+                          { 
+                            "id": "help-button", 
+                            "icon": "info",
+                            "url": "https://www.eclipse.org/modeling/emf/",
+                            "hint": "EMF Homepage" 
+                          } 
+                    ]
+    
+                },
+    
+                {
+    
+                    "id": "xmi",
+    
+                    "name": "XMI",
+    
+                    "panelclass": "ProgramPanel",
+    
+                    "icon": "xmi",
+    
+                    "language": "xmi",
+    
+                    "buttons" : [ 
+                        { 
+                          "id": "refresh-button", 
+                          "icon": "refresh",
+                          "renderfunction": "function-xmitodiagram",
+                          "hint": "Render the model object diagram" 
+                        }, 
+                        { 
+                          "id": "help-button", 
+                          "icon": "info",
+                          "url": "https://www.omg.org/spec/XMI/",
+                          "hint": "OMG - XML Metadata Interchange" 
+                        }          
+                    ]
+    
+                }
+    
+            ]
+        }
+    
+    
     }
-
-
-} 


### PR DESCRIPTION
This PR adjusts the EMF tool definition so that Ecore files can be displayed on the platform in a panel. The panel includes a button and function for rendering a meta-model diagram, which is currently a bit naughtily just reusing the EMFatic rendering function and an existing conversion function from Ecore to EMFatic.