### PR TITLE
Fix Xtext tool config webserver offline after scheduled shutdown

### DIFF
--- a/xtext/start.sh
+++ b/xtext/start.sh
@@ -7,8 +7,8 @@ echo Old builds cleaned.
 rm -rf ${ES_UPLOAD_LOCATION}/*
 echo Old uploads cleaned.
 
-find ${ES_DEPLOY_FILE_LOCATION}/ -type f -not -name 'ROOT.war' -delete
-find ${ES_DEPLOY_FILE_LOCATION}/ -mindepth 1 -type d -not -name 'ROOT' -exec rm -rf {} \+ 
+find ${ES_DEPLOY_FILE_LOCATION}/ -mindepth 1 -maxdepth 1 -type f -not -name 'ROOT.war' -delete
+find ${ES_DEPLOY_FILE_LOCATION}/ -mindepth 1 -maxdepth 1 -type d -exec rm -rf {} \+ 
 echo Old editor instances cleaned.
 
 # start tomcat


### PR DESCRIPTION
Change to  the Xtext tool editorserver  to remove the xtext config file webserver app deploy directory (ROOT) so that it redeployed by tomcat on startup. Set min and max find depth so the deploy location is not searched recursively and the containing directory is excluded.