### PR TITLE
Check for file existence before trying to read

### DIFF
--- a/xtext/editorserver/src/controllers/XtextController.js
+++ b/xtext/editorserver/src/controllers/XtextController.js
@@ -28,6 +28,14 @@ class XtextController {
 
             console.log(`started build of ${req.file.filename}`)
 
+            // Report any stdout and stderr output on the server console to aid debugging
+            build.stdout.on('data', (data) => {
+                console.log(`stdout: ${data}`);
+            });
+            build.stderr.on('data', (data) => {
+                console.error(`stderr: ${data}`);
+            });
+
             build.on('close', (code) => {
                 console.log(`building ${req.file.filename} completed with code ${code}`);
             }); 

--- a/xtext/editorserver/src/controllers/XtextController.js
+++ b/xtext/editorserver/src/controllers/XtextController.js
@@ -57,7 +57,11 @@ class XtextController {
 
             // Read the build log
             try {
-                buildLog = fs.readFileSync(buildLogPath, 'utf8');
+                if (fs.existsSync(buildLogPath)) {
+                    buildLog = fs.readFileSync(buildLogPath, 'utf8');
+                } else {
+                    buildLog = "";
+                }
             } catch (err) {
                 console.log("Error reading build log: " + buildLogPath);
                 console.log(err);
@@ -65,7 +69,11 @@ class XtextController {
 
             // Read the build status
             try {
-                buildStatus = Number( fs.readFileSync(buildStatusPath, 'utf8') );
+                if (fs.existsSync(buildStatusPath)) {
+                    buildStatus = Number( fs.readFileSync(buildStatusPath, 'utf8') );
+                } else {
+                    buildStatus = 0;
+                }
             } catch (err) {
                 console.log("Error reading build status: " + buildStatusPath);
                 console.log(err);


### PR DESCRIPTION
There was a bug where the XtextController did not check for the existence of the build log file when trying to read during a status update. This could be triggered by a race condition between the build process and the status checks and could crash the controller as a consequence. 

This PR adds defensive checks for the existence of these files before reading them.