### PR TITLE
Updated editor configuration for xtext-to-xmi conversion function

### DIFF
--- a/xtext/editorserver/editor_tool.json
+++ b/xtext/editorserver/editor_tool.json
@@ -7,8 +7,8 @@
                 "id": "function-xtext-to-xmi",
                 "name": "xtext-to-xmi",
 
-                "parameters": [ {"name":"input", "type":"xtext-generated"}, 
-                                {"name":"language", "type":"text"}],
+                "parameters": [ {"name":"input", "type":"xtext-generated","instanceOf": "metamodel"},
+                                {"name":"metamodel", "type":"ecore"}],
 
                 "returnType": "xmi",
 


### PR DESCRIPTION
Change to support the use of language workbench outputs in activities https://github.com/mdenet/educationplatform/issues/173.

Updated editor tools' platform configuration file xtext-to-xmi conversion function to match the expected format that includes instanceOf for model types.