### PR TITLE
Better object diagrams

### DIFF
--- a/xtext/editorserver/model2plantuml.egl
+++ b/xtext/editorserver/model2plantuml.egl
@@ -24,7 +24,7 @@ object "[%=e.getNodeLabel()%]" as [%=e.getNodeId()%] #[%=colors.get(e.eClass().e
 [%for (v in r.at(0).select(r|M.allInstances().includes(r))){%]
 [%if (r.at(1).eOpposite.isUndefined() or r.at(1).eOpposite.name.compareTo(r.at(1).name) > 0){%]
 
-[%=e.getNodeId()%] --> [%=v.getNodeId()%] [%=getReferenceLabel(e, v, r.at(1))%][%if (r.at(0).size()>1) {%][[%=r.at(0).indexOf(v)%]][%}%]
+[%=e.getNodeId()%] [%if (r.at(1).isContainment){%]*[%}%]--> [%=v.getNodeId()%] [%=getReferenceLabel(e, v, r.at(1))%][%if (r.at(0).size()>1) {%][[%=r.at(0).indexOf(v)%]][%}%]
 [%}}}}%]
 	
 @enduml

--- a/xtext/editorserver/model2plantuml.egl
+++ b/xtext/editorserver/model2plantuml.egl
@@ -24,32 +24,8 @@ object "[%=e.getNodeLabel()%]" as [%=e.getNodeId()%] #[%=colors.get(e.eClass().e
 [%for (v in r.at(0).select(r|M.allInstances().includes(r))){%]
 [%if (r.at(1).eOpposite.isUndefined() or r.at(1).eOpposite.name.compareTo(r.at(1).name) > 0){%]
 
-[%=e.getNodeId()%] --> [%=v.getNodeId()%] [%=getReferenceLabel(e, v, r.at(1))%]
+[%=e.getNodeId()%] --> [%=v.getNodeId()%] [%=getReferenceLabel(e, v, r.at(1))%][%if (r.at(0).size()>1) {%][[%=r.at(0).indexOf(v)%]][%}%]
 [%}}}}%]
-
-[*Generate validation nodes*]
-[%if (unsatisfiedConstraints.isDefined()){%]
-[%for (uc in unsatisfiedConstraints){%]
-note top of [%=uc.getInstance().getNodeId()%] #[%=uc.getConstraint().getConstraintColour()%]
-  [%=uc.getMessage()%]
-end note
-[%}%]
-[%}%]
-
-[*Generate pattern nodes*]
-[%if (matches.isDefined()){%]
-[%for (match in matches){%]
-[%var matchNodeId = "match" + loopCount;%]
-note "[%=match.pattern.name%]" as [%=matchNodeId%] #gold
-
-[%for (key in match.roleBindings.keySet()){%]
-[%var values = match.roleBindings.get(key).asSequence();%]
-[%for (value in values){%]
-[%=matchNodeId%] .. [%=value.getNodeId()%]: [%=key%]
-[%}%]
-[%}%]
-[%}%]
-[%}%]
 	
 @enduml
 [%
@@ -89,12 +65,12 @@ operation Any getReferenced() {
 }
 operation getReferenceLabel(s, t, r) {
 	
-	for (ref in s.eClass().getEAllReferences()) {
-		if (ref.eType.isSuperTypeOf(t.eClass()) and r <> ref) {
+//	for (ref in s.eClass().getEAllReferences()) {
+//		if (ref.eType.isSuperTypeOf(t.eClass()) and r <> ref) {
 			return " : " + r.name;
-		}
-	}
-	return "";
+//		}
+//	}
+//	return "";
 }
 
 operation Integer mod(i : Integer) {


### PR DESCRIPTION
This PR improves the rendering of object diagrams for Xtext models by

- removing some unnecessary code from the generation file
- always generating association names
- generating sequence numbers where more than one object are referenced
- generating distinguishing markers for containment and non-containment edges